### PR TITLE
[R2] Add anim, layout, menu, plurals, and style support for R2

### DIFF
--- a/butterknife-gradle-plugin/src/main/java/butterknife/plugin/FinalRClassBuilder.java
+++ b/butterknife-gradle-plugin/src/main/java/butterknife/plugin/FinalRClassBuilder.java
@@ -26,7 +26,8 @@ import static javax.lang.model.element.Modifier.STATIC;
 public final class FinalRClassBuilder {
   private static final String SUPPORT_ANNOTATION_PACKAGE = "android.support.annotation";
   private static final String[] SUPPORTED_TYPES = {
-      "array", "attr", "bool", "color", "dimen", "drawable", "id", "integer", "string"
+      "anim", "array", "attr", "bool", "color", "dimen", "drawable", "id", "integer", "layout", "menu", "plurals",
+      "string", "style"
   };
 
   private FinalRClassBuilder() { }

--- a/butterknife-gradle-plugin/src/test/resources/fixtures/R.java
+++ b/butterknife-gradle-plugin/src/test/resources/fixtures/R.java
@@ -1,43 +1,63 @@
 package com.example.butterknife;
 
 public final class R {
-  public static final class anim {
+  public static final class unsupported {
     public static int res = 0x7f040000;
   }
 
-  public static final class array {
+  public static final class anim {
     public static int res = 0x7f040001;
   }
 
-  public static final class attr {
+  public static final class array {
     public static int res = 0x7f040002;
   }
 
-  public static final class bool {
+  public static final class attr {
     public static int res = 0x7f040003;
   }
 
-  public static final class color {
+  public static final class bool {
     public static int res = 0x7f040004;
   }
 
-  public static final class dimen {
+  public static final class color {
     public static int res = 0x7f040005;
   }
 
-  public static final class drawable {
+  public static final class dimen {
     public static int res = 0x7f040006;
   }
 
-  public static final class id {
+  public static final class drawable {
     public static int res = 0x7f040007;
   }
 
-  public static final class integer {
+  public static final class id {
     public static int res = 0x7f040008;
   }
 
-  public static final class string {
+  public static final class integer {
     public static int res = 0x7f040009;
+  }
+
+  public static final class layout {
+    public static int res = 0x7f040010;
+  }
+
+  public static final class menu {
+    public static int res = 0x7f040011;
+  }
+
+  public static final class plurals {
+    public static int res = 0x7f040012;
+  }
+
+  public static final class string {
+    public static int res = 0x7f040013;
+  }
+
+  public static final class style {
+    public static int res = 0x7f040014;
   }
 }

--- a/butterknife-gradle-plugin/src/test/resources/fixtures/R2.java
+++ b/butterknife-gradle-plugin/src/test/resources/fixtures/R2.java
@@ -1,6 +1,7 @@
 // Generated code from Butter Knife gradle plugin. Do not modify!
 package com.butterknife.example;
 
+import android.support.annotation.AnimRes;
 import android.support.annotation.ArrayRes;
 import android.support.annotation.AttrRes;
 import android.support.annotation.BoolRes;
@@ -9,51 +10,80 @@ import android.support.annotation.DimenRes;
 import android.support.annotation.DrawableRes;
 import android.support.annotation.IdRes;
 import android.support.annotation.IntegerRes;
+import android.support.annotation.LayoutRes;
+import android.support.annotation.MenuRes;
+import android.support.annotation.PluralsRes;
 import android.support.annotation.StringRes;
+import android.support.annotation.StyleRes;
 
 public final class R2 {
+  public static final class anim {
+    @AnimRes
+    public static final int res = 0x7f040001;
+  }
+
   public static final class array {
     @ArrayRes
-    public static final int res = 0x7f040001;
+    public static final int res = 0x7f040002;
   }
 
   public static final class attr {
     @AttrRes
-    public static final int res = 0x7f040002;
+    public static final int res = 0x7f040003;
   }
 
   public static final class bool {
     @BoolRes
-    public static final int res = 0x7f040003;
+    public static final int res = 0x7f040004;
   }
 
   public static final class color {
     @ColorRes
-    public static final int res = 0x7f040004;
+    public static final int res = 0x7f040005;
   }
 
   public static final class dimen {
     @DimenRes
-    public static final int res = 0x7f040005;
+    public static final int res = 0x7f040006;
   }
 
   public static final class drawable {
     @DrawableRes
-    public static final int res = 0x7f040006;
+    public static final int res = 0x7f040007;
   }
 
   public static final class id {
     @IdRes
-    public static final int res = 0x7f040007;
+    public static final int res = 0x7f040008;
   }
 
   public static final class integer {
     @IntegerRes
-    public static final int res = 0x7f040008;
+    public static final int res = 0x7f040009;
+  }
+
+  public static final class layout {
+    @LayoutRes
+    public static final int res = 0x7f040010;
+  }
+
+  public static final class menu {
+    @MenuRes
+    public static final int res = 0x7f040011;
+  }
+
+  public static final class plurals {
+    @PluralsRes
+    public static final int res = 0x7f040012;
   }
 
   public static final class string {
     @StringRes
-    public static final int res = 0x7f040009;
+    public static final int res = 0x7f040013;
+  }
+
+  public static final class style {
+    @StyleRes
+    public static final int res = 0x7f040014;
   }
 }

--- a/butterknife-gradle-plugin/src/test/resources/fixtures/RFinal.java
+++ b/butterknife-gradle-plugin/src/test/resources/fixtures/RFinal.java
@@ -1,39 +1,59 @@
 package com.example.butterknife;
 
 public final class R {
-  public static final class array {
+  public static final class anim {
     public static final int res = 0x7f040001;
   }
 
-  public static final class attr {
+  public static final class array {
     public static final int res = 0x7f040002;
   }
 
-  public static final class bool {
+  public static final class attr {
     public static final int res = 0x7f040003;
   }
 
-  public static final class color {
+  public static final class bool {
     public static final int res = 0x7f040004;
   }
 
-  public static final class dimen {
+  public static final class color {
     public static final int res = 0x7f040005;
   }
 
-  public static final class drawable {
+  public static final class dimen {
     public static final int res = 0x7f040006;
   }
 
-  public static final class id {
+  public static final class drawable {
     public static final int res = 0x7f040007;
   }
 
-  public static final class integer {
+  public static final class id {
     public static final int res = 0x7f040008;
   }
 
-  public static final class string {
+  public static final class integer {
     public static final int res = 0x7f040009;
+  }
+
+  public static final class layout {
+    public static final int res = 0x7f040010;
+  }
+
+  public static final class menu {
+    public static final int res = 0x7f040011;
+  }
+
+  public static final class plurals {
+    public static final int res = 0x7f040012;
+  }
+
+  public static final class string {
+    public static final int res = 0x7f040013;
+  }
+
+  public static final class style {
+    public static final int res = 0x7f040014;
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.jakewharton
-VERSION_NAME=8.5.1
+VERSION_NAME=8.5.1.4-airbnb
 
 POM_DESCRIPTION=Field and method binding for Android views.
 


### PR DESCRIPTION
Makes it so Butterknife's Gradle plugin won't ignore animations, layouts, menus, plurals, or styles when generating R2. Most notably this enables the use of layout and style resources as annotation values for Epoxy and n2.

The relevant tests are passing though there is a test failure that I think is caused by @BenSchwab's earlier change.